### PR TITLE
Change path separator to Linux friendly for StateGame

### DIFF
--- a/src/StateGame.c
+++ b/src/StateGame.c
@@ -1,7 +1,7 @@
 #include "Banks/SetBank2.h"
 
-#include "..\res\src\tiles.h"
-#include "..\res\src\map.h"
+#include "../res/src/tiles.h"
+#include "../res/src/map.h"
 
 #include "ZGBMain.h"
 #include "Scroll.h"


### PR DESCRIPTION
A small change to make the default template compatible with Linux by default.
Should be ok for Windows since other includes in the template also use the Unix style separators (`#include "Banks/SetBank2.h"`).